### PR TITLE
Allow controlling the behaviour of `stride(A::AbstractArray, k::Integer)` after loading the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Types of changes:
   for `k > ndims(A)`:
   - `virtual_strides_return_error`
   - `virtual_strides_return_zero`
+  - `virtual_strides_return_next_stride`
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ Types of changes:
 
 - Functions to set the behavior of `stride(A::AbstractArray, k::Integer)`
   for `k > ndims(A)`:
-  - `virtual_strides_return_error`
-  - `virtual_strides_return_zero`
-  - `virtual_strides_return_next_stride`
+  - `virtual_strides_return_error`,
+  - `virtual_strides_return_zero`,
+  - `virtual_strides_return_next_stride`,
+  - `virtual_strides_call_next_stride`.
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Types of changes:
 - Functions to set the behavior of `stride(A::AbstractArray, k::Integer)`
   for `k > ndims(A)`:
   - `virtual_strides_return_error`
+  - `virtual_strides_return_zero`
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Types of changes:
 
 ## [Unreleased]
 
+## Added
+
+- Functions to set the behavior of `stride(A::AbstractArray, k::Integer)`
+  for `k > ndims(A)`:
+  - `virtual_strides_return_error`
+
 ## Changed
 
 - Allow the package to be precompiled by moving some code into `__init__()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ Types of changes:
 
 ## Added
 
-- Functions to set the behavior of `stride(A::AbstractArray, k::Integer)`
-  for `k > ndims(A)`:
+- Functions to set the behavior of `stride(A::AbstractArray, k::Integer)` for `k > ndims(A)`:
   - `virtual_strides_return_error`,
   - `virtual_strides_return_zero`,
   - `virtual_strides_return_next_stride`,
   - `virtual_strides_call_next_stride`.
+- Function `set_virtual_strides_behavior(::VirtualStridesBehavior)` to set the behavior of
+  `stride(A::AbstractArray, k::Integer)` for `k > ndims(A)` via an instance of
+  the enumeration `VirtualStridesBehavior`.
 
 ## Changed
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -60,6 +60,23 @@ julia> stride(a, 4), stride(p, 4), stride(v, 4)
 
 whereas this code would return `(105, 123, -3)` without loading [`NextStride`](@ref).
 
+### Configuring the behavior
+
+The behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
+for `k > ndims(A)` can be configured by calling the function
+[`set_virtual_strides_behavior(B::VirtualStridesBehavior)`](@ref)
+with one of the following instances of the enumeration [`VirtualStridesBehavior`](@ref):
+
+1. `ReturnError`: returns an error;
+2. `ReturnZero`: returns `0` (use with caution!);
+3. `ReturnNextStride`: returns the "next stride" of `A`;
+4. `Call_next_stride`: calls [`next_stride(A)`](@ref).
+
+Notice that with option (3) the functions [`stride`](@extref Base.stride) and
+[`next_stride`](@ref) remain independent of one another (and can therefore be specialized
+separately), whereas with option (4) they become coupled (adding methods to
+[`next_stride`](@ref) will affect the value returned by [`stride`](@extref Base.stride)).
+
 ## API
 
 ### Index

--- a/src/NextStride.jl
+++ b/src/NextStride.jl
@@ -8,6 +8,7 @@ export next_stride
 # public virtual_strides_return_error
 # public virtual_strides_return_zero
 # public virtual_strides_return_next_stride
+# public virtual_strides_call_next_stride
 
 
 """
@@ -94,6 +95,24 @@ function virtual_strides_return_next_stride()
         else
             sz = size(A) :: NTuple{N,Integer}
             return sum((sz .- 1) .* abs.(st); init=1)
+        end
+    end
+end
+
+
+"""
+    virtual_strides_call_next_stride
+
+Set the behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
+to call [`next_stride(A)`](@ref) if `k > ndims(A)`.
+"""
+function virtual_strides_call_next_stride()
+    @eval function Base.stride(A::AbstractArray{T,N}, k::Integer)::Integer where {T,N}
+        st = strides(A) :: NTuple{N,Integer}
+        if 1 <= k && k <= N
+            return st[k]
+        else
+            return next_stride(A)
         end
     end
 end

--- a/src/NextStride.jl
+++ b/src/NextStride.jl
@@ -2,6 +2,11 @@ module NextStride
 
 export next_stride
 
+# Marking items with `public` requires `VERSION >= v"1.11"`.
+# We can do so if we elevate the minimum supported Julia version.
+#
+# public virtual_strides_return_error
+
 
 """
     next_stride(A::AbstractArray) :: Integer
@@ -35,6 +40,24 @@ function next_stride end
 # Here we are relying on the assumption `all(size(A) .> 0)`,
 # otherwise we should put `size(A) .- 1.` inside `abs.()`.
 @inline next_stride(A::AbstractArray)::Integer = sum((size(A) .- 1) .* abs.(strides(A)); init=1)
+
+
+"""
+    virtual_strides_return_error()
+
+Set the behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
+to return an error if `k > ndims(A)`.
+"""
+function virtual_strides_return_error()
+    @eval function Base.stride(A::AbstractArray{T,N}, k::Integer)::Integer where {T,N}
+        st = strides(A) :: NTuple{N,Integer}
+        if 1 <= k && k <= N
+            return st[k]
+        else
+            error("array strides: dimension must be positive")
+        end
+    end
+end
 
 
 function __init__()

--- a/src/NextStride.jl
+++ b/src/NextStride.jl
@@ -53,6 +53,7 @@ function next_stride end
 Set the behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
 to return an error if `k > ndims(A)`.
 """
+function virtual_strides_return_error end
 function virtual_strides_return_error()
     @eval function Base.stride(A::AbstractArray{T,N}, k::Integer)::Integer where {T,N}
         st = strides(A) :: NTuple{N,Integer}
@@ -66,11 +67,12 @@ end
 
 
 """
-    virtual_strides_return_zero
+    virtual_strides_return_zero()
 
 Set the behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
 to return `0` if `k > ndims(A)`.
 """
+function virtual_strides_return_zero end
 function virtual_strides_return_zero()
     @eval function Base.stride(A::AbstractArray{T,N}, k::Integer)::Integer where {T,N}
         st = strides(A) :: NTuple{N,Integer}
@@ -84,11 +86,12 @@ end
 
 
 """
-    virtual_strides_return_next_stride
+    virtual_strides_return_next_stride()
 
 Set the behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
 to return the "next stride" if `k > ndims(A)`.
 """
+function virtual_strides_return_next_stride end
 function virtual_strides_return_next_stride()
     @eval function Base.stride(A::AbstractArray{T,N}, k::Integer)::Integer where {T,N}
         st = strides(A) :: NTuple{N,Integer}
@@ -103,11 +106,12 @@ end
 
 
 """
-    virtual_strides_call_next_stride
+    virtual_strides_call_next_stride()
 
 Set the behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
 to call [`next_stride(A)`](@ref) if `k > ndims(A)`.
 """
+function virtual_strides_call_next_stride end
 function virtual_strides_call_next_stride()
     @eval function Base.stride(A::AbstractArray{T,N}, k::Integer)::Integer where {T,N}
         st = strides(A) :: NTuple{N,Integer}
@@ -157,6 +161,7 @@ Set the behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride
 for `k > ndims(A)` according to the specification `B`, which must be an instance
 of the enumeration [`VirtualStridesBehavior`](@ref).
 """
+function set_virtual_strides_behavior end
 function set_virtual_strides_behavior(B::VirtualStridesBehavior)
     @eval function Base.stride(A::AbstractArray{T,N}, k::Integer)::Integer where {T,N}
         st = strides(A) :: NTuple{N,Integer}

--- a/src/NextStride.jl
+++ b/src/NextStride.jl
@@ -5,7 +5,9 @@ export next_stride
 # Marking items with `public` requires `VERSION >= v"1.11"`.
 # We can do so if we elevate the minimum supported Julia version.
 #
-# public virtual_strides_return_error, virtual_strides_return_zero
+# public virtual_strides_return_error
+# public virtual_strides_return_zero
+# public virtual_strides_return_next_stride
 
 
 """
@@ -73,6 +75,25 @@ function virtual_strides_return_zero()
             return st[k]
         else
             return 0
+        end
+    end
+end
+
+
+"""
+    virtual_strides_return_next_stride
+
+Set the behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
+to return the *next stride* if `k > ndims(A)`.
+"""
+function virtual_strides_return_next_stride()
+    @eval function Base.stride(A::AbstractArray{T,N}, k::Integer)::Integer where {T,N}
+        st = strides(A) :: NTuple{N,Integer}
+        if 1 <= k && k <= N
+            return st[k]
+        else
+            sz = size(A) :: NTuple{N,Integer}
+            return sum((sz .- 1) .* abs.(st); init=1)
         end
     end
 end

--- a/src/NextStride.jl
+++ b/src/NextStride.jl
@@ -5,7 +5,7 @@ export next_stride
 # Marking items with `public` requires `VERSION >= v"1.11"`.
 # We can do so if we elevate the minimum supported Julia version.
 #
-# public virtual_strides_return_error
+# public virtual_strides_return_error, virtual_strides_return_zero
 
 
 """
@@ -55,6 +55,24 @@ function virtual_strides_return_error()
             return st[k]
         else
             error("array strides: dimension must be positive")
+        end
+    end
+end
+
+
+"""
+    virtual_strides_return_zero
+
+Set the behavior of [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
+to return `0` if `k > ndims(A)`.
+"""
+function virtual_strides_return_zero()
+    @eval function Base.stride(A::AbstractArray{T,N}, k::Integer)::Integer where {T,N}
+        st = strides(A) :: NTuple{N,Integer}
+        if 1 <= k && k <= N
+            return st[k]
+        else
+            return 0
         end
     end
 end

--- a/src/NextStride.jl
+++ b/src/NextStride.jl
@@ -141,10 +141,17 @@ Instances of this enumeration are passed to the function
 [`stride(A::AbstractArray, k::Integer)`](@extref Base.stride)
 for `k > ndims(A)` according to this specification:
 
-- `ReturnError`: returns an error;
-- `ReturnZero`: returns `0` (use with caution!);
-- `ReturnNextStride`: returns the "next stride" of `A`;
-- `Call_next_stride`: calls [`next_stride(A)`](@ref).
+1. `ReturnError`: returns an error;
+2. `ReturnZero`: returns `0` (use with caution!);
+3. `ReturnNextStride`: returns the "next stride" of `A`;
+4. `Call_next_stride`: calls [`next_stride(A)`](@ref).
+
+Notice that with option (3) the functions [`stride`](@extref Base.stride) and
+[`next_stride`](@ref) remain independent of one another (and can therefore be
+specialized separately), whereas with option (4) they become coupled (adding
+methods to [`next_stride`](@ref) will affect the value returned by
+[`stride`](@extref Base.stride)).
+
 """
 @enum VirtualStridesBehavior begin
     ReturnError


### PR DESCRIPTION
Closes #2.